### PR TITLE
Fix NoneType errors on validation

### DIFF
--- a/src/generators/datatypes/float.py
+++ b/src/generators/datatypes/float.py
@@ -24,7 +24,9 @@ class FloatType:
             end_at > min_value and \
             end_at < max_value
 
-        return is_start_valid and is_end_valid
+        return is_start_valid and \
+            is_end_valid and \
+            start_at < end_at
 
     def generate(self) -> float:
         return round(uniform(self.start_at, self.end_at), self.decimal_floor)

--- a/src/generators/datatypes/integer.py
+++ b/src/generators/datatypes/integer.py
@@ -17,7 +17,8 @@ class IntegerType:
             start_at < 2147483648 and \
             end_at is not None and \
             end_at > -2147483648 and \
-            end_at < 2147483648
+            end_at < 2147483648 and \
+            start_at < end_at
 
     def generate(self) -> int:
         return randint(self.start_at, self.end_at)

--- a/src/generators/datatypes/integer.py
+++ b/src/generators/datatypes/integer.py
@@ -12,8 +12,12 @@ class IntegerType:
     def check(generator):
         start_at = generator.get("start_at")
         end_at = generator.get("end_at")
-        return start_at > -2147483648 and start_at < 2147483648 \
-            and end_at > -2147483648 and end_at < 2147483648
+        return start_at is not None and \
+            start_at > -2147483648 and \
+            start_at < 2147483648 and \
+            end_at is not None and \
+            end_at > -2147483648 and \
+            end_at < 2147483648
 
     def generate(self) -> int:
         return randint(self.start_at, self.end_at)

--- a/src/generators/datatypes/sequence.py
+++ b/src/generators/datatypes/sequence.py
@@ -10,7 +10,9 @@ class SequenceType:
         start_at = generator.get("start_at")
         if not isinstance(start_at, int):
             return False
-        return start_at > -2147483648 and start_at < 2147483648
+        return start_at is not None and \
+            start_at > -2147483648 and \
+            start_at < 2147483648
 
     def generate_records(self, num_of_rows) -> list:
         return self.__generate_sequence(num_of_rows, self.step)

--- a/src/generators/datatypes/sequence_timestamp.py
+++ b/src/generators/datatypes/sequence_timestamp.py
@@ -41,6 +41,9 @@ class TimestampSequenceType:
     def check(generator):
         start_at = generator.get("start_at")
 
+        if start_at is None:
+            return False
+
         try:
             isoparse(start_at)
         except ValueError:

--- a/src/generators/datatypes/timestamp.py
+++ b/src/generators/datatypes/timestamp.py
@@ -20,6 +20,9 @@ class TimestampType:
         start_at = generator.get("start_at")
         end_at = generator.get("end_at")
 
+        if start_at is None or end_at is None:
+            return False
+
         try:
             isoparse(start_at)
             isoparse(end_at)

--- a/src/generators/datatypes/timestamp.py
+++ b/src/generators/datatypes/timestamp.py
@@ -24,11 +24,12 @@ class TimestampType:
             return False
 
         try:
-            isoparse(start_at)
-            isoparse(end_at)
+            start_at = isoparse(start_at)
+            end_at = isoparse(end_at)
+
+            return start_at < end_at
         except ValueError:
             return False
-        return True
 
     def generate(self) -> datetime:
         dt_start_at = self.__parse_to_datetime(self.start_date)


### PR DESCRIPTION
Fix the error of NoneType on validations of generators defined on spec. Now they all go to the default error message.