### PR TITLE
Fix Date Format on JSON and CSV

### DIFF
--- a/src/generators/basehandler.py
+++ b/src/generators/basehandler.py
@@ -14,29 +14,38 @@ class BaseHandler(object):
     def __init__(self):
         self.inspector = ConfigurationInpector()
 
-    def __validate(self, clazz, iterable, **kwargs):
+    def __validate(self, clazz, iterable, trace, **kwargs):
         for item in iterable:
-            rules = clazz.get_rules(item, **kwargs)
+            try:
+                rules = clazz.get_rules(item, **kwargs)
+            except ValueError as err:
+                type_ = item.get('type', '')
+                name = item.get('name', type_)
+                message = (f"Key {trace}{name} ({err})")
+                raise ValueError(message)
             self.inspector.inspect_rules(rules=rules['required'],
                                          configuration=item)
             self.inspector.inspect_rules(rules=rules['optional'],
                                          configuration=item,
                                          optional=True)
 
-    def __validate_fields(self, dataset):
+    def __validate_fields(self, dataset, trace):
         fields = dataset['fields']
         self.__validate(clazz=FieldsConfiguration,
                         iterable=fields,
-                        locale=dataset['locale'])
+                        locale=dataset['locale'],
+                        trace=f"{trace}fields.")
 
-    def __validate_format(self, dataset):
+    def __validate_format(self, dataset, trace):
         self.__validate(clazz=FormattersConfiguration,
-                        iterable=[dataset['format']])
+                        iterable=[dataset['format']],
+                        trace=f"{trace}format.")
 
-    def __validate_serializers(self, dataset):
+    def __validate_serializers(self, dataset, trace):
         serializers = dataset['serializers']['to']
         self.__validate(clazz=SerializersConfiguration,
-                        iterable=serializers)
+                        iterable=serializers,
+                        trace=f"{trace}serializers.to.")
 
     def valid_specification(self, file_path):
         with open(file_path, 'r') as file:
@@ -51,9 +60,10 @@ class BaseHandler(object):
         for dataset_key in configuration['datasets']:
             dataset = configuration['datasets'][dataset_key]
 
-            self.__validate_fields(dataset)
-            self.__validate_format(dataset)
-            self.__validate_serializers(dataset)
+            trace = f"datasets.{dataset_key}."
+            self.__validate_fields(dataset, trace)
+            self.__validate_format(dataset, trace)
+            self.__validate_serializers(dataset, trace)
         return configuration
 
     def generate_dataframe(self, specification: dict, size) -> DataFrame:

--- a/src/generators/basehandler.py
+++ b/src/generators/basehandler.py
@@ -2,7 +2,7 @@ import json
 
 from pandas import DataFrame, Series
 
-from src.lib.config import general_rules
+from src.lib.config import general_rules, datetime_rules
 from src.lib.config.fields import FieldsConfiguration
 from src.lib.config.formatters import FormattersConfiguration
 from src.lib.config.inspector import ConfigurationInpector
@@ -64,6 +64,19 @@ class BaseHandler(object):
             self.__validate_fields(dataset, trace)
             self.__validate_format(dataset, trace)
             self.__validate_serializers(dataset, trace)
+
+        for dataset_key in configuration['datasets']:
+            has_datetime = False
+            dataset = configuration['datasets'][dataset_key]
+            for field in dataset['fields']:
+                if field.get('type') == 'date_time':
+                    has_datetime = True
+                    break
+            if has_datetime:
+                self.inspector \
+                    .inspect_rules(rules=datetime_rules,
+                                   configuration=dataset)
+
         return configuration
 
     def generate_dataframe(self, specification: dict, size) -> DataFrame:

--- a/src/generators/datatypes/sequence_timestamp.py
+++ b/src/generators/datatypes/sequence_timestamp.py
@@ -56,8 +56,13 @@ class TimestampSequenceType:
             except ValueError:
                 raise ValueError(f"Timestamp field `{value}` "
                                  "has a wrong format")
-        return {'required': {'generator.start_at': {
-            'none': False,
-            'type': str,
-            'custom': [validate]}},
-            'optional': {}}
+        return {
+            'required': {
+                'generator.start_at': {
+                    'none': False,
+                    'type': str,
+                    'custom': [validate]
+                }
+            },
+            'optional': {}
+        }

--- a/src/lib/config/__init__.py
+++ b/src/lib/config/__init__.py
@@ -7,3 +7,12 @@ general_rules = {
     "datasets.{*}.format.type": {'type': str, 'none': False},
     "datasets.{*}.serializers.to.[*].type": {'type': str, 'none': False}
 }
+
+datetime_rules = {
+    "format.options": {'type': dict, 'none': False},
+    "format.options.date_format": {
+        'type': str,
+        'none': False,
+        'values': ['iso', 'epoch']
+    }
+}

--- a/src/lib/config/inspector.py
+++ b/src/lib/config/inspector.py
@@ -40,14 +40,12 @@ class ConfigurationInpector(object):
             raise ValueError(f"JSON Key `{trace}` must be "
                              f"of type `{expected_type}`")
 
-        if 'values' not in expected:
-            return
-
-        expected_values = expected.get('values', None)
-        if self.__validate_values(value=value,
-                                  expected_values=expected_values):
-            raise ValueError(f"JSON Key `{trace}` is invalid, these are "
-                             f"the possible options: `{expected_values}`")
+        if 'values' in expected:
+            expected_values = expected.get('values', None)
+            if self.__validate_values(value=value,
+                                      expected_values=expected_values):
+                raise ValueError(f"JSON Key `{trace}` is invalid, these are "
+                                 f"the possible options: `{expected_values}`")
 
         custom_rules = expected.get('custom', [])
         if len(custom_rules) > 0:
@@ -65,10 +63,10 @@ class ConfigurationInpector(object):
 
         if match(r'[{\[].*[}\]]', current_key):
             if current_key[1] == '*':  # Iterable
+                if len(configuration) <= 0:
+                    raise ValueError(f"Key '{trace}{current_key}' has "
+                                     "no valid values")
                 if current_key[0] == '[':  # List
-                    if len(configuration) <= 0:
-                        raise ValueError(f"Key '{trace}{current_key}' has "
-                                         "no valid values")
                     for index in range(0, len(configuration)):
                         item = configuration[index]
                         key_trace = f"{trace}{index}."

--- a/src/lib/config/inspector.py
+++ b/src/lib/config/inspector.py
@@ -2,24 +2,29 @@ from re import match
 
 
 class ConfigurationInpector(object):
+
     def __validate_none(self, value, expected):
         return expected.get('none') is False and value is None
 
     def __validate_type(self, value, expected):
         return not isinstance(value, expected['type'])
 
+    def __validate_values(self, value, expected_values):
+        return value not in expected_values
+
     def __validate(self,
                    configuration: dict,
                    rule: str,
                    expected: dict,
-                   optional: bool):
+                   optional: bool,
+                   trace):
         keys = rule.split('.')
         key = keys[0]
 
         if self.__validate_none(value=configuration.get(key),
                                 expected=expected) and \
            optional is False:
-            raise ValueError(f"JSON Key `{key}` can not "
+            raise ValueError(f"JSON Key `{trace}` can not "
                              "be `None`, `null` or empty")
         elif optional is True:
             return
@@ -32,8 +37,17 @@ class ConfigurationInpector(object):
             expected_type = expected['type']
             if expected_type == dict:
                 expected_type = type(expected_type)
-            raise ValueError(f"JSON Key `{key}` must be "
+            raise ValueError(f"JSON Key `{trace}` must be "
                              f"of type `{expected_type}`")
+
+        if 'values' not in expected:
+            return
+
+        expected_values = expected.get('values', None)
+        if self.__validate_values(value=value,
+                                  expected_values=expected_values):
+            raise ValueError(f"JSON Key `{trace}` is invalid, these are "
+                             f"the possible options: `{expected_values}`")
 
         custom_rules = expected.get('custom', [])
         if len(custom_rules) > 0:
@@ -44,61 +58,76 @@ class ConfigurationInpector(object):
                      configuration: dict,
                      rule: str,
                      expected: dict,
-                     optional: bool = False):
+                     optional: bool = False,
+                     trace=""):
         current_key = rule.split('.')[0]
         partial_rule = rule.replace(f'{current_key}.', "")
 
         if match(r'[{\[].*[}\]]', current_key):
             if current_key[1] == '*':  # Iterable
                 if current_key[0] == '[':  # List
-                    for item in configuration:
-                        return self.inspect_rule(configuration=item,
-                                                 expected=expected,
-                                                 rule=partial_rule,
-                                                 optional=optional)
-                    raise ValueError(f"Key '{current_key}' has "
-                                     "no valid values")
+                    if len(configuration) <= 0:
+                        raise ValueError(f"Key '{trace}{current_key}' has "
+                                         "no valid values")
+                    for index in range(0, len(configuration)):
+                        item = configuration[index]
+                        key_trace = f"{trace}{index}."
+                        self.inspect_rule(configuration=item,
+                                          expected=expected,
+                                          rule=partial_rule,
+                                          optional=optional,
+                                          trace=key_trace)
+                    return
                 else:  # Dict
                     for key in configuration.keys():
-                        return self.inspect_rule(
+                        key_trace = f"{trace}{key}."
+                        self.inspect_rule(
                             configuration=configuration[key],
                             expected=expected,
                             rule=partial_rule,
-                            optional=optional
+                            optional=optional,
+                            trace=key_trace
                         )
+                    return
             else:  # Fixed Index
                 index = current_key[1:-1]
+                key_trace = f"{trace}{index}"
                 if current_key[0] == '[':  # List
                     index = int(index)
                     return self.inspect_rule(
                         configuration=configuration[index],
                         expected=expected,
                         rule=partial_rule,
-                        optional=optional
+                        optional=optional,
+                        trace=key_trace
                     )
                 else:  # Dict
                     return self.inspect_rule(
                         configuration=configuration[index],
                         expected=expected,
                         rule=partial_rule,
-                        optional=optional
+                        optional=optional,
+                        trace=key_trace
                     )
 
         self.__validate(configuration=configuration,
                         rule=rule,
                         expected=expected,
-                        optional=optional)
+                        optional=optional,
+                        trace=f"{trace}{current_key}")
         if '.' not in rule or \
            (current_key not in configuration and optional is True):
             return
         return self.inspect_rule(configuration=configuration[current_key],
                                  expected=expected,
                                  rule=partial_rule,
-                                 optional=optional)
+                                 optional=optional,
+                                 trace=f"{trace}{current_key}.")
 
-    def inspect_rules(self, rules, configuration, optional=False):
+    def inspect_rules(self, rules, configuration, optional=False, trace=""):
         for rule_key in rules.keys():
             self.inspect_rule(rule=rule_key,
                               expected=rules[rule_key],
                               configuration=configuration,
-                              optional=optional)
+                              optional=optional,
+                              trace=trace)

--- a/src/lib/formatters/csv.py
+++ b/src/lib/formatters/csv.py
@@ -1,5 +1,6 @@
 import csv
 
+from datetime import datetime
 from pandas import DataFrame
 
 
@@ -22,6 +23,13 @@ class CsvFormatter(object):
                     'options.index': {'none': False, 'type': bool}
                 }}
 
+    def __date_format(self, parameters):
+        date_format = parameters.get('date_format')
+        if date_format == 'iso':
+            pass
+        else:
+            return ''
+
     def format(self, dataframe: DataFrame, path_or_buffer) -> None:
         """Format dataframe to csv.
 
@@ -31,6 +39,18 @@ class CsvFormatter(object):
         parameters = self.default
         options = self.specification.get('options', {})
         parameters.update(options)
+
+        date_format = options.get('date_format')
+        if date_format == 'epoch':
+            parameters.pop('date_format')
+            epoch = datetime(1970, 1, 1)
+            for column in dataframe.columns:
+                if dataframe[column].dtype == 'datetime64[ns]':
+                    dataframe[column] = \
+                        dataframe[column].apply(lambda x: int((x - epoch)
+                                                .total_seconds()))
+        elif date_format == 'iso':
+            parameters.update({'date_format': '%Y-%m-%dT%H:%M:%SZ'})
 
         if dataframe.shape[0] > 0:
             return dataframe.to_csv(path_or_buf=path_or_buffer,

--- a/src/lib/formatters/csv.py
+++ b/src/lib/formatters/csv.py
@@ -23,13 +23,6 @@ class CsvFormatter(object):
                     'options.index': {'none': False, 'type': bool}
                 }}
 
-    def __date_format(self, parameters):
-        date_format = parameters.get('date_format')
-        if date_format == 'iso':
-            pass
-        else:
-            return ''
-
     def format(self, dataframe: DataFrame, path_or_buffer) -> None:
         """Format dataframe to csv.
 
@@ -55,7 +48,3 @@ class CsvFormatter(object):
         if dataframe.shape[0] > 0:
             return dataframe.to_csv(path_or_buf=path_or_buffer,
                                     quoting=csv.QUOTE_NONNUMERIC, **parameters)
-
-    @staticmethod
-    def check(*args, **kwargs):
-        return True

--- a/src/lib/formatters/json.py
+++ b/src/lib/formatters/json.py
@@ -8,7 +8,8 @@ class JsonFormatter(object):
     key = 'json-array'
 
     def __init__(self, specification={}):
-        self.default = {'orient': 'records'}
+        self.default = {'orient': 'records',
+                        'date_unit': 's'}
         self.specification = specification
 
     @staticmethod

--- a/src/tests/generators/handler_fixtures.py
+++ b/src/tests/generators/handler_fixtures.py
@@ -241,3 +241,49 @@ def valid_dryrun():
                 "generator": {"start_at": 10}
             }]
             }
+
+
+@fixture
+def invalid_dateformat():
+    return {"datasets": {
+        "teste3": {
+            "fields": [{"type": "integer:sequence",
+                                "name": "id",
+                                "generator": {"start_at": 1}},
+                       {"type": "date_time",
+                                "name": "created_at",
+                                "generator": {}}],
+            "size": 1000,
+            "locale": "pt_BR",
+            "format": {"type": "csv",
+                       "options": {
+                           "header": True,
+                           "sep": ","
+                       }},
+            "serializers": {
+                "to": [{"type": "file",
+                        "uri": "/tmp/teste.csv"}]}}}}
+
+
+@fixture
+def malformed_json():
+    return "[]]"
+
+
+@fixture
+def unknown_type_spec():
+    return {"datasets": {
+        "teste3": {
+            "fields": [{"type": "timestamp",
+                        "name": "created_at",
+                        "generator": {}}],
+            "size": 1000,
+            "locale": "pt_BR",
+            "format": {"type": "csv",
+                       "options": {
+                           "header": True,
+                           "sep": ","
+                       }},
+            "serializers": {
+                "to": [{"type": "file",
+                        "uri": "/tmp/teste.csv"}]}}}}

--- a/src/tests/generators/test_basehundler.py
+++ b/src/tests/generators/test_basehundler.py
@@ -210,3 +210,26 @@ class TestBaseHundler(object):
         with pytest.raises(ValueError):
             handler.valid_specification('invalid_spec.json')
         remove('invalid_spec.json')
+
+    def test_date_format_invalid_specification(self,
+                                               mocker,
+                                               invalid_dateformat):
+        with patch('builtins.open',
+                   mock_open(read_data=json.dumps(invalid_dateformat))):
+            handler = BaseHandler()
+            with pytest.raises(ValueError):
+                handler.valid_specification('')
+
+    def test_malformed_json(self, mocker, malformed_json):
+        with patch('builtins.open',
+                   mock_open(read_data=malformed_json)):
+            handler = BaseHandler()
+            with pytest.raises(ValueError):
+                handler.valid_specification('')
+
+    def test_unknown_type(self, mocker, unknown_type_spec):
+        with patch('builtins.open',
+                   mock_open(read_data=json.dumps(unknown_type_spec))):
+            handler = BaseHandler()
+            with pytest.raises(ValueError):
+                handler.valid_specification('')

--- a/src/tests/generators/test_handler.py
+++ b/src/tests/generators/test_handler.py
@@ -249,17 +249,12 @@ class TestGeneratorsHandler(object):
 
     def test_invalid_no_ids_spec_handler(self, mocker,
                                          invalid_no_ids_dataset):
-        from os.path import abspath
-        from uuid import uuid4
-
-        absolute_path = abspath(".")
-        file_name = uuid4()
-        with open(f"{absolute_path}/{file_name}", "w") as f:
-            json.dump(invalid_no_ids_dataset, f)
-
-        with pytest.raises(ValueError):
-            GeneratorsHandler({"config_file": f"{absolute_path}/{file_name}"})
-        remove(f"{absolute_path}/{file_name}")
+        with patch('builtins.open',
+                   mock_open(read_data=json
+                             .dumps(invalid_no_ids_dataset))) as mock:
+            with pytest.raises(ValueError):
+                GeneratorsHandler({"config_file": ""})
+            mock.assert_called()
 
     def test_invalid_no_dataset_spec_handler(self, mocker,
                                              no_datasets_specification):

--- a/src/tests/lib/config/fixtures.py
+++ b/src/tests/lib/config/fixtures.py
@@ -67,10 +67,7 @@ def invalid_specfication(format_type):
                      'type': 'integer:sequence'},
                     {'name': 'reference_id',
                      'type': 'integer:sequence',
-                     'generator': {
-                         'start_at': 2147483649,
-                         'end_at': -2147483649
-                     }},
+                     'generator': {}},
                     {'name': 'level',
                      'type': 'integer',
                      'generator': {
@@ -128,9 +125,7 @@ def invalid_specfication(format_type):
                      'type': 'timestamp:sequence'},
                     {'name': 'fired_at',
                      'type': 'timestamp:sequence',
-                     'generator': {
-                         'start_at': '20:11:02 20201102'
-                     }},
+                     'generator': {}},
                 ],
                 'format': {
                     'type': format_type
@@ -273,3 +268,22 @@ def invalid_s3_key():
             }}
         ]
     }
+
+
+@fixture
+def expected_values_rule():
+    return {'items.{*}.age': {'none': False,
+                              'type': str,
+                              'values': ['3', '9']}}
+
+
+def custom_rule_method(value):
+    if value != 3:
+        raise ValueError("Test value is different, expected: 3")
+
+
+@fixture
+def custom_rule():
+    return {'items.{*}.age': {'none': False,
+                              'type': str,
+                              'custom': [custom_rule_method]}}

--- a/src/tests/lib/config/test_fields.py
+++ b/src/tests/lib/config/test_fields.py
@@ -28,6 +28,7 @@ class TestFieldsConfiguration(object):
         fields = dataset['fields']
 
         for field in fields:
+            print(field)
             with raises(ValueError):
                 rules = FieldsConfiguration.get_rules(field, dataset['locale'])
                 required = rules['required']

--- a/src/tests/lib/config/test_inspector.py
+++ b/src/tests/lib/config/test_inspector.py
@@ -62,3 +62,19 @@ class TestConfigurationInspector(object):
         with raises(ValueError):
             inspector.inspect_rules(rules=fixed_key_rule,
                                     configuration=dictionary_sample)
+
+    def test_expected_values_rule(self,
+                                  expected_values_rule,
+                                  dictionary_sample):
+        inspector = ConfigurationInpector()
+
+        with raises(ValueError):
+            inspector.inspect_rules(rules=expected_values_rule,
+                                    configuration=dictionary_sample)
+
+    def test_custom_rule(self, custom_rule, dictionary_sample):
+        inspector = ConfigurationInpector()
+
+        with raises(ValueError):
+            inspector.inspect_rules(rules=custom_rule,
+                                    configuration=dictionary_sample)

--- a/src/tests/lib/formatters/fixtures.py
+++ b/src/tests/lib/formatters/fixtures.py
@@ -20,3 +20,16 @@ def pandas_dataframe_with_data():
 @fixture
 def pandas_dataframe_without_data():
     return pandas_dataframe(data=[])
+
+
+@fixture
+def dataframe_with_datetime():
+    from dateutil.parser import isoparse
+
+    data = [{"Column": "Value_1", "at": "2020-10-01 00:00:00"},
+            {"Column": "Value_2", "at": "2020-10-01 00:00:00"},
+            {"Column": "Value_3", "at": "2020-10-01 00:00:00"}]
+    df = pandas_dataframe(data=data)
+    df['at'] = df['at'].apply(lambda x: isoparse(x))
+
+    return df

--- a/src/tests/lib/formatters/test_csv.py
+++ b/src/tests/lib/formatters/test_csv.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from datetime import datetime
 
 from src.lib.formatters.csv import CsvFormatter
 from src.tests.lib.formatters.fixtures import *  # noqa: F403, F401
@@ -26,3 +27,31 @@ class TestCsvFormatter(object):
 
         assert isinstance(buffer.getvalue(), str) is True
         assert len(buffer.getvalue()) == 0
+
+    def test_date_format_epoch(self, dataframe_with_datetime):
+        buffer = StringIO()
+        spec = {'options': {'date_format': 'epoch'}}
+        csv_writer = CsvFormatter(specification=spec)
+        csv_writer.format(dataframe=dataframe_with_datetime,
+                          path_or_buffer=buffer)
+
+        csv_text = buffer.getvalue()
+        assert isinstance(csv_text, str) is True
+        assert len(csv_text) > 0
+
+        for date_ in dataframe_with_datetime['at'].tolist():
+            assert str(date_) in csv_text
+
+    def test_date_format_iso(self, dataframe_with_datetime):
+        buffer = StringIO()
+        spec = {'options': {'date_format': 'iso'}}
+        csv_writer = CsvFormatter(specification=spec)
+        csv_writer.format(dataframe=dataframe_with_datetime,
+                          path_or_buffer=buffer)
+
+        csv_text = buffer.getvalue()
+        assert isinstance(csv_text, str) is True
+        assert len(csv_text) > 0
+
+        for date_ in dataframe_with_datetime['at'].tolist():
+            assert date_.isoformat() in csv_text

--- a/src/tests/lib/formatters/test_csv.py
+++ b/src/tests/lib/formatters/test_csv.py
@@ -1,5 +1,4 @@
 from io import StringIO
-from datetime import datetime
 
 from src.lib.formatters.csv import CsvFormatter
 from src.tests.lib.formatters.fixtures import *  # noqa: F403, F401


### PR DESCRIPTION
A problem involving pandas methods cause files to create datetime columsn with different formats.

These are the changes:
- fix(inspector): remove return that blocks the loop
- feat(date_time): add a alternative flux to validate date_format specifications
- feat(date_format): add for csv and json formats options to wirte datetime correctly
- refactor(code): remove unnecessary code
- style(code): dict format
- feat(tests): add tests and some fixes