### PR TITLE
Feature Truncate and Replace

### DIFF
--- a/src/lib/formatters/__init__.py
+++ b/src/lib/formatters/__init__.py
@@ -1,7 +1,9 @@
 from src.lib.formatters.csv import CsvFormatter
 from src.lib.formatters.json import JsonFormatter
+from src.lib.formatters.sql import SQLFormatter
 
 formatters = {
     CsvFormatter.key: CsvFormatter,
-    JsonFormatter.key: JsonFormatter
+    JsonFormatter.key: JsonFormatter,
+    SQLFormatter.key: SQLFormatter
 }

--- a/src/lib/formatters/sql.py
+++ b/src/lib/formatters/sql.py
@@ -110,7 +110,3 @@ class SQLFormatter(object):
         return f"INSERT INTO {table_name} " \
                f"({', '.join(columns)}) \n"\
                "VALUES\n" + ',\n'.join(values)
-
-    @staticmethod
-    def check(*args, **kwargs):
-        return True

--- a/src/tests/lib/config/fixtures.py
+++ b/src/tests/lib/config/fixtures.py
@@ -217,6 +217,11 @@ def json_format_sample():
 
 
 @fixture
+def sql_format_sample():
+    return {'type': 'sql'}
+
+
+@fixture
 def unknown_format_sample():
     return {'type': 'unknown'}
 

--- a/src/tests/lib/config/test_formatters.py
+++ b/src/tests/lib/config/test_formatters.py
@@ -19,6 +19,12 @@ class TestFormattersConfiguration(object):
         assert rules is not None
         assert isinstance(rules, dict) is True
 
+    def test_sql(self, sql_format_sample):
+        rules = FormattersConfiguration.get_rules(sql_format_sample)
+
+        assert rules is not None
+        assert isinstance(rules, dict) is True
+
     def test_unknown(self, unknown_format_sample):
         with raises(ValueError):
             FormattersConfiguration.get_rules(unknown_format_sample)

--- a/src/tests/lib/formatters/test_sql.py
+++ b/src/tests/lib/formatters/test_sql.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from pytest import raises
 
 from src.lib.formatters.sql import SQLFormatter
 from src.tests.lib.formatters.fixtures import *  # noqa: F403, F401
@@ -10,7 +11,7 @@ class TestSqlFormatter(object):
     def test_writting_dataframe_with_records(self,
                                              pandas_dataframe_with_data):
         buffer = StringIO()
-        csv_writer = SQLFormatter(specification={
+        sql_writer = SQLFormatter(specification={
             'options': {
                 'table_name': 'mytable',
                 'batch_size': 2,
@@ -21,7 +22,7 @@ class TestSqlFormatter(object):
                 }
             }
         })
-        csv_writer.format(dataframe=pandas_dataframe_with_data,
+        sql_writer.format(dataframe=pandas_dataframe_with_data,
                           path_or_buffer=buffer)
 
         assert isinstance(buffer.getvalue(), str) is True
@@ -46,3 +47,69 @@ class TestSqlFormatter(object):
 
         assert isinstance(buffer.getvalue(), str) is True
         assert len(buffer.getvalue()) == 0
+
+    def test_truncate(self, pandas_dataframe_with_data):
+        buffer = StringIO()
+        table_name = 'mytable'
+        sql_writer = SQLFormatter(specification={
+            'options': {
+                'mode': 'truncate',
+                'table_name': table_name,
+                'batch_size': 2,
+                'schema': {
+                    'Column': {
+                        'quoted': True
+                    }
+                }
+            }
+        })
+        sql_writer.format(dataframe=pandas_dataframe_with_data,
+                          path_or_buffer=buffer)
+
+        text = buffer.getvalue()
+        assert isinstance(text, str) is True
+        assert len(text) > 0
+        assert f'TRUNCATE {table_name}' in text
+
+    def test_replace(self, pandas_dataframe_with_data):
+        buffer = StringIO()
+        table_name = 'mytable'
+        sql_writer = SQLFormatter(specification={
+            'options': {
+                'mode': 'replace',
+                'table_name': table_name,
+                'batch_size': 2,
+                'schema': {
+                    'Column': {
+                        'quoted': True
+                    }
+                }
+            }
+        })
+        sql_writer.format(dataframe=pandas_dataframe_with_data,
+                          path_or_buffer=buffer)
+
+        text = buffer.getvalue()
+        assert isinstance(text, str) is True
+        assert len(text) > 0
+        assert f'DROP TABLE IF EXISTS {table_name};' in text
+
+    def test_invalid_mode(self, pandas_dataframe_with_data):
+        buffer = StringIO()
+        table_name = 'mytable'
+        sql_writer = SQLFormatter(specification={
+            'options': {
+                'mode': 'invalid',
+                'table_name': table_name,
+                'batch_size': 2,
+                'schema': {
+                    'Column': {
+                        'quoted': True
+                    }
+                }
+            }
+        })
+
+        with raises(ValueError):
+            sql_writer.format(dataframe=pandas_dataframe_with_data,
+                              path_or_buffer=buffer)


### PR DESCRIPTION
Update code to support truncate and replace. Forward I added a else to  throw an error if mode is unkown.

Notes:
- feat(table): add replace and truncate code on the methods and some fixes to work properly
- refactor(formatters): add SQLFormatter on the formatters map to be recognized
- refactor(code): remove unecessary method named check
- feat(sql_formatter): add tests for truncate, replace and unknown modes