### PR TITLE
Feature Mysql Client Writer

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ requests = "==2.23.0"
 gcsfs = "==0.6.0"
 s3fs = "==0.4.0"
 faker = "==4.0.1"
+mysqlclient = "==1.4.6"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c9f1e502654e1ec2d2c5ebdadbc51ec37c6089dd6ec695a68b29ed063dd75a8e"
+            "sha256": "6e9e74db5f75b14e9d77dfcce60734448d377fb93dcffce111d3622b4a4cd213"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -124,6 +124,16 @@
                 "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
             ],
             "version": "==0.9.5"
+        },
+        "mysqlclient": {
+            "hashes": [
+                "sha256:4c82187dd6ab3607150fbb1fa5ef4643118f3da122b8ba31c3149ddd9cf0cb39",
+                "sha256:9e6080a7aee4cc6a06b58b59239f20f1d259c1d2fddf68ddeed242d2311c7087",
+                "sha256:f3fdaa9a38752a3b214a6fe79d7cae3653731a53e577821f9187e67cbecb2e16",
+                "sha256:f646f8d17d02be0872291f258cce3813497bc7888cd4712a577fd1e719b2f213"
+            ],
+            "index": "pypi",
+            "version": "==1.4.6"
         },
         "numpy": {
             "hashes": [
@@ -298,10 +308,10 @@
         },
         "aws-xray-sdk": {
             "hashes": [
-                "sha256:263a38f3920d9dc625e3acb92e6f6d300f4250b70f538bd009ce6e485676ab74",
-                "sha256:612dba6efc3704ef224ac0747b05488b8aad94e71be3ece4edbc051189d50482"
+                "sha256:8dfa785305fc8dc720d8d4c2ec6a58e85e467ddc3a53b1506a2ed8b5801c8fc7",
+                "sha256:ae57baeb175993bdbf31f83843e2c0958dd5aa8cb691ab5628aafb6ccc78a0fc"
             ],
-            "version": "==2.4.3"
+            "version": "==2.5.0"
         },
         "boto": {
             "hashes": [
@@ -366,10 +376,10 @@
         },
         "cfn-lint": {
             "hashes": [
-                "sha256:3ff2a77214777360516945d06cbbbeecddc9c7969832b6e1b699f94144b89317",
-                "sha256:58652622b28732223a9a4c2b5625c5f4f4d9509bbf8d06b1b891a1ef9782f1fd"
+                "sha256:9873c82b710c60eacdbed68faebd835e2f0108a037babc1c7ccd3ed7d7e921e5",
+                "sha256:c101073c5af8eb23fbccb44f5482604384d3593c6298543d072403eb7469b4ef"
             ],
-            "version": "==0.29.4"
+            "version": "==0.29.5"
         },
         "chardet": {
             "hashes": [
@@ -380,39 +390,39 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:03f630aba2b9b0d69871c2e8d23a69b7fe94a1e2f5f10df5049c0df99db639a0",
-                "sha256:046a1a742e66d065d16fb564a26c2a15867f17695e7f3d358d7b1ad8a61bca30",
-                "sha256:0a907199566269e1cfa304325cc3b45c72ae341fbb3253ddde19fa820ded7a8b",
-                "sha256:165a48268bfb5a77e2d9dbb80de7ea917332a79c7adb747bd005b3a07ff8caf0",
-                "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823",
-                "sha256:1f66cf263ec77af5b8fe14ef14c5e46e2eb4a795ac495ad7c03adc72ae43fafe",
-                "sha256:2e08c32cbede4a29e2a701822291ae2bc9b5220a971bba9d1e7615312efd3037",
-                "sha256:3844c3dab800ca8536f75ae89f3cf566848a3eb2af4d9f7b1103b4f4f7a5dad6",
-                "sha256:408ce64078398b2ee2ec08199ea3fcf382828d2f8a19c5a5ba2946fe5ddc6c31",
-                "sha256:443be7602c790960b9514567917af538cac7807a7c0c0727c4d2bbd4014920fd",
-                "sha256:4482f69e0701139d0f2c44f3c395d1d1d37abd81bfafbf9b6efbe2542679d892",
-                "sha256:4a8a259bf990044351baf69d3b23e575699dd60b18460c71e81dc565f5819ac1",
-                "sha256:513e6526e0082c59a984448f4104c9bf346c2da9961779ede1fc458e8e8a1f78",
-                "sha256:5f587dfd83cb669933186661a351ad6fc7166273bc3e3a1531ec5c783d997aac",
-                "sha256:62061e87071497951155cbccee487980524d7abea647a1b2a6eb6b9647df9006",
-                "sha256:641e329e7f2c01531c45c687efcec8aeca2a78a4ff26d49184dce3d53fc35014",
-                "sha256:65a7e00c00472cd0f59ae09d2fb8a8aaae7f4a0cf54b2b74f3138d9f9ceb9cb2",
-                "sha256:6ad6ca45e9e92c05295f638e78cd42bfaaf8ee07878c9ed73e93190b26c125f7",
-                "sha256:73aa6e86034dad9f00f4bbf5a666a889d17d79db73bc5af04abd6c20a014d9c8",
-                "sha256:7c9762f80a25d8d0e4ab3cb1af5d9dffbddb3ee5d21c43e3474c84bf5ff941f7",
-                "sha256:85596aa5d9aac1bf39fe39d9fa1051b0f00823982a1de5766e35d495b4a36ca9",
-                "sha256:86a0ea78fd851b313b2e712266f663e13b6bc78c2fb260b079e8b67d970474b1",
-                "sha256:8a620767b8209f3446197c0e29ba895d75a1e272a36af0786ec70fe7834e4307",
-                "sha256:922fb9ef2c67c3ab20e22948dcfd783397e4c043a5c5fa5ff5e9df5529074b0a",
-                "sha256:9fad78c13e71546a76c2f8789623eec8e499f8d2d799f4b4547162ce0a4df435",
-                "sha256:a37c6233b28e5bc340054cf6170e7090a4e85069513320275a4dc929144dccf0",
-                "sha256:c3fc325ce4cbf902d05a80daa47b645d07e796a80682c1c5800d6ac5045193e5",
-                "sha256:cda33311cb9fb9323958a69499a667bd728a39a7aa4718d7622597a44c4f1441",
-                "sha256:db1d4e38c9b15be1521722e946ee24f6db95b189d1447fa9ff18dd16ba89f732",
-                "sha256:eda55e6e9ea258f5e4add23bcf33dc53b2c319e70806e180aecbff8d90ea24de",
-                "sha256:f372cdbb240e09ee855735b9d85e7f50730dcfb6296b74b95a3e5dea0615c4c1"
+                "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a",
+                "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355",
+                "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65",
+                "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7",
+                "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9",
+                "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1",
+                "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0",
+                "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55",
+                "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c",
+                "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6",
+                "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef",
+                "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019",
+                "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e",
+                "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0",
+                "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf",
+                "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24",
+                "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2",
+                "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c",
+                "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4",
+                "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0",
+                "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd",
+                "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04",
+                "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e",
+                "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730",
+                "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2",
+                "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768",
+                "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796",
+                "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7",
+                "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a",
+                "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489",
+                "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"
             ],
-            "version": "==5.0.4"
+            "version": "==5.1"
         },
         "cryptography": {
             "hashes": [
@@ -505,10 +515,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
-                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "version": "==2.11.1"
+            "version": "==2.11.2"
         },
         "jmespath": {
             "hashes": [
@@ -533,10 +543,10 @@
         },
         "jsonpickle": {
             "hashes": [
-                "sha256:71bca2b80ae28af4e3f86629ef247100af7f97032b5ca8d791c1f8725b411d95",
-                "sha256:efc6839cb341985f0c24f98650a4c1063a2877c236ffd3d7e1662f0c482bac93"
+                "sha256:3d71018794242f6b1640f779a94a192500f73ceed9ef579b4f01799171ec3fb3",
+                "sha256:e8ca6ec3f379f5eee6e11380d48db220aacc282b480dea46b11cc6f6009d1cdb"
             ],
-            "version": "==1.3"
+            "version": "==1.4"
         },
         "jsonpointer": {
             "hashes": [

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -46,7 +46,7 @@ def generate_datasets(spec_path):
             click.echo("| Finished!\n"
                        f"| Dataset name: {dset_name}\n"
                        f"| Dataset format: {dset_format}\n"
-                       f"| Dataset path: {dset_path}\n")
+                       f"| Dataset: {dset_path}\n")
     except Exception as err:
         click.echo(f"Error: {err}")
 

--- a/src/generators/handler.py
+++ b/src/generators/handler.py
@@ -3,6 +3,7 @@ from pandas import DataFrame
 from src.lib.formatters import formatters
 from src.lib.writers import writers
 from src.generators.basehandler import BaseHandler
+from src.lib.config.serializers import SerializersConfiguration
 
 
 class GeneratorsHandler(object):
@@ -50,7 +51,7 @@ class GeneratorsHandler(object):
         method = 'before_write'
 
         if hasattr(writer, method) and \
-           callable(getattr(writer, method)):
+           callable(writer.before_write):
             writer.before_write()
 
     def write_dataframe(self,
@@ -63,8 +64,12 @@ class GeneratorsHandler(object):
         self.__before_format(formatter)
 
         destination_type = destination['type']
+
+        if destination_type not in writers:
+            destination_type = \
+                SerializersConfiguration.get_database_type(destination)
+
         writer_class = writers[destination_type]
         writer = writer_class(formatter=formatter, specification=destination)
         self.__before_write(writer)
-
         return writer.write(dataframe=dataframe)

--- a/src/generators/handler.py
+++ b/src/generators/handler.py
@@ -35,6 +35,24 @@ class GeneratorsHandler(object):
         dataframe = self.base.generate_dataframe(specification, size)
         return dataframe
 
+    def __before_format(self, formatter):
+        '''
+           Supposed to checks if a method called 'before_format'
+        exists and if it does, call it.
+        '''
+        pass
+
+    def __before_write(self, writer):
+        '''
+           Checks if a method called 'before_write'
+        exists and if it does, call it.
+        '''
+        method = 'before_write'
+
+        if hasattr(writer, method) and \
+           callable(getattr(writer, method)):
+            writer.before_write()
+
     def write_dataframe(self,
                         dataframe: DataFrame,
                         destination: dict,
@@ -42,9 +60,11 @@ class GeneratorsHandler(object):
         file_format = format_['type']
         formatter_class = formatters[file_format]
         formatter = formatter_class(specification=format_)
+        self.__before_format(formatter)
 
         destination_type = destination['type']
         writer_class = writers[destination_type]
         writer = writer_class(formatter=formatter, specification=destination)
+        self.__before_write(writer)
 
         return writer.write(dataframe=dataframe)

--- a/src/lib/config/serializers.py
+++ b/src/lib/config/serializers.py
@@ -1,14 +1,23 @@
-from src.lib.writers import writers
+from src.lib.writers import writers, database_writers
 
 
 class SerializersConfiguration(object):
+
+    @staticmethod
+    def get_database_type(serializer):
+        options = serializer.get('options', {})
+        engine = options.get('engine')
+        method = options.get('method')
+        return f"{engine}-{method}"
 
     @staticmethod
     def get_rules(serializer):
         type_ = serializer.get('type')
 
         if type_ not in writers:
-            raise ValueError(f"Serializer type `{type_}` not found")
+            type_ = SerializersConfiguration.get_database_type(serializer)
+            if type_ not in database_writers:
+                raise ValueError(f"Serializer type `{type_}` not found")
 
         type_class = writers.get(type_)
 

--- a/src/lib/formatters/__init__.py
+++ b/src/lib/formatters/__init__.py
@@ -1,7 +1,9 @@
 from src.lib.formatters.csv import CsvFormatter
 from src.lib.formatters.json import JsonFormatter
+from src.lib.formatters.sql import SQLFormatter
 
 formatters = {
     CsvFormatter.key: CsvFormatter,
-    JsonFormatter.key: JsonFormatter
+    JsonFormatter.key: JsonFormatter,
+    SQLFormatter.key: SQLFormatter
 }

--- a/src/lib/formatters/sql.py
+++ b/src/lib/formatters/sql.py
@@ -50,19 +50,34 @@ class SQLFormatter(object):
             else:
                 path_or_buffer.write(data)
 
-    def replace(self, options: dict):
-        pass
+    def replace(self, options: dict, dataframe):
+        table_name = options.get("table_name")
+        query = f"DROP TABLE IF EXISTS {table_name};\n\n"
+        query += self.append(options, dataframe)
+        return query
 
-    def truncate(self, options: dict):
-        pass
+    def truncate(self, options: dict, dataframe):
+        table_name = options.get("table_name")
+        query = f"TRUNCATE {table_name};\n\n"
+        query += self.append(options, dataframe)
+        return query
 
     def __format(self, parameters, dataframe):
+        mode = parameters.get("mode")
+
         if parameters.get('index'):
             dataframe.index.name = parameters.get('index_label')
             dataframe = dataframe.reset_index(level=0)
 
-        if parameters.get("mode") == "append":
+        if mode == "append":
             return self.append(parameters=parameters, dataframe=dataframe)
+        elif mode == "replace":
+            return self.replace(parameters, dataframe)
+        elif mode == "truncate":
+            return self.truncate(parameters, dataframe)
+        else:
+            raise ValueError(f"Mode `{mode}` is invalid, expected:"
+                             " 'append', 'truncate' or 'replace'")
 
     def append(self, parameters: dict, dataframe: DataFrame) -> str:
         table_name = parameters.get("table_name")
@@ -77,7 +92,8 @@ class SQLFormatter(object):
             query += ";\n\n"
         return query
 
-    def insert_statement(self, dataframe: DataFrame, table_name: str,
+    def insert_statement(self, dataframe: DataFrame,
+                         table_name: str,
                          schema: dict):
         columns = dataframe.columns
         values = self.__parse_rows(dataframe, schema)
@@ -106,7 +122,3 @@ class SQLFormatter(object):
                 row_value_sql += str(row[column])
         row_value_sql += ")"
         return row_value_sql
-
-    @staticmethod
-    def check(*args, **kwargs):
-        return True

--- a/src/lib/mysql/connection.py
+++ b/src/lib/mysql/connection.py
@@ -1,0 +1,29 @@
+from MySQLdb import Connect
+
+
+class MysqlConnection(object):
+
+    def __init__(self, host, user, password, port, database):
+        self.connection = Connect(host=host,
+                                  user=user,
+                                  passwd=password,
+                                  port=port,
+                                  db=database)
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def __del__(self):
+        self.close()
+
+    def execute_query(self, query, *args):
+        with self.connection \
+                 .cursor() as cursor:
+            cursor.execute(query, *args)
+            query_result = cursor.info()
+
+        self.connection.commit()
+        return query_result
+
+    def close(self):
+        self.connection.close()

--- a/src/lib/mysql/connection.py
+++ b/src/lib/mysql/connection.py
@@ -3,24 +3,23 @@ from MySQLdb import Connect
 
 class MysqlConnection(object):
 
-    def __init__(self, host, user, password, port, database):
+    def __init__(self, host, username, password, port, database, **kwargs):
         self.connection = Connect(host=host,
-                                  user=user,
+                                  user=username,
                                   passwd=password,
                                   port=port,
                                   db=database)
 
-    def __exit__(self, type, value, traceback):
-        self.close()
+    def __enter__(self):
+        return self
 
-    def __del__(self):
+    def __exit__(self, type, value, traceback):
         self.close()
 
     def execute_query(self, query, *args):
         with self.connection \
                  .cursor() as cursor:
-            cursor.execute(query, *args)
-            query_result = cursor.info()
+            query_result = cursor.execute(query, *args)
 
         self.connection.commit()
         return query_result

--- a/src/lib/writers/__init__.py
+++ b/src/lib/writers/__init__.py
@@ -4,6 +4,7 @@ from src.lib.writers.remotes.s3_presigned_url import S3PresignedUrlRemoteWriter
 from src.lib.writers.remotes.gcs import GCSRemoteWriter
 from src.lib.writers.\
     remotes.gcs_presigned_url import GCSPresignedUrlRemoteWriter
+from src.lib.writers.databases.mysql import MysqlDatabaseWriter
 
 writers = {
     's3-url': S3PresignedUrlRemoteWriter,
@@ -16,4 +17,9 @@ uri_writers = {
     'gcs-url': GCSPresignedUrlRemoteWriter
 }
 
+database_writers = {
+    'mysql-cli': MysqlDatabaseWriter
+}
+
 writers.update(uri_writers)
+writers.update(database_writers)

--- a/src/lib/writers/databases/mysql.py
+++ b/src/lib/writers/databases/mysql.py
@@ -1,0 +1,34 @@
+from pandas import DataFrame
+
+from src.lib.mysql.connection import MysqlConnection
+
+
+class MysqlDatabaseWriter(object):
+    key = 'sql'
+
+    def __init__(self, formatter, specification):
+        self.formatter = formatter
+        self.specification = specification
+
+    @staticmethod
+    def rules(self):
+        return {
+            'required': {
+                'options.host': {'none': False, 'type': str},
+                'options.username': {'none': False, 'type': str},
+                'options.database': {'none': False, 'type': str}
+            },
+            'optional': {
+                'options.port': {'none': False, 'type': str},
+                'options.schema': {'none': False, 'type': str}
+            }
+        }
+
+    def write(self, dataframe: DataFrame):
+        parameters = self.specification \
+                         .get('options')
+
+        with MysqlConnection(**parameters) as connection:
+            query = self.formatter \
+                        .format(dataframe=dataframe)
+            return connection.execute_query(query)

--- a/src/lib/writers/databases/mysql.py
+++ b/src/lib/writers/databases/mysql.py
@@ -1,3 +1,4 @@
+from getpass import getpass
 from pandas import DataFrame
 
 from src.lib.mysql.connection import MysqlConnection
@@ -11,7 +12,7 @@ class MysqlDatabaseWriter(object):
         self.specification = specification
 
     @staticmethod
-    def rules(self):
+    def rules():
         return {
             'required': {
                 'options.host': {'none': False, 'type': str},
@@ -24,11 +25,31 @@ class MysqlDatabaseWriter(object):
             }
         }
 
+    def before_write(self):
+        host = self.specification \
+                   .get('options') \
+                   .get('host')
+        user = self.specification \
+                   .get('options') \
+                   .get('username')
+        print(f"Database host: {host}")
+        print(f"Username: {user}")
+        self.specification['options']['password'] = \
+            getpass(f"Type {user} password: ")
+
     def write(self, dataframe: DataFrame):
+        row_count = 0
         parameters = self.specification \
                          .get('options')
 
-        with MysqlConnection(**parameters) as connection:
-            query = self.formatter \
-                        .format(dataframe=dataframe)
-            return connection.execute_query(query)
+        sql = self.formatter \
+                  .format(dataframe=dataframe,
+                          path_or_buffer=None)
+        if sql is not None:
+            with MysqlConnection(**parameters) as connection:
+                for query in sql.split(';'):
+                    if len(query) < 6:
+                        continue
+                    row_count += connection.execute_query(query)
+
+        return f"{row_count} rows inserted"

--- a/src/lib/writers/remotes/gcs_presigned_url.py
+++ b/src/lib/writers/remotes/gcs_presigned_url.py
@@ -7,24 +7,26 @@ from urllib.parse import urlparse
 
 class GCSPresignedUrlRemoteWriter(object):
     key = 'gcs-url'
+    signed_url = None
 
     def __init__(self, formatter, specification):
         self.formatter = formatter
         self.specification = specification
 
+    def before_write(self):
+        self.signed_url = self.specification.get('uri')
+
+        if not self.signed_url:
+            self.signed_url = input("Enter the signed url: ")
+
     def write(self, dataframe: DataFrame):
-        signed_url = self.specification.get('uri')
-
-        if not signed_url:
-            signed_url = input("Enter the signed url: ")
-
         buffer = StringIO()
 
         self.formatter.format(dataframe=dataframe,
                               path_or_buffer=buffer)
 
         try:
-            response = requests.put(signed_url,
+            response = requests.put(self.signed_url,
                                     data=buffer.getvalue())
             response.raise_for_status()
         except Exception as e:

--- a/src/lib/writers/remotes/s3_presigned_url.py
+++ b/src/lib/writers/remotes/s3_presigned_url.py
@@ -8,22 +8,23 @@ from pandas import DataFrame
 
 class S3PresignedUrlRemoteWriter(object):
     key = 's3-url'
+    file_path = None
 
     def __init__(self, formatter, specification):
         self.formatter = formatter
         self.specification = specification
 
-    def write(self, dataframe: DataFrame):
+    def before_write(self):
         options = self.specification.get('options')
 
-        if options is not None:
-            file_path = options['path']
-        else:
+        if options is None:
             file_path = input("Enter the signed url json file path: ")
             if os.path.isfile(file_path) is False:
                 raise ValueError('File not found')
+            self.file_path = file_path
 
-        with open(file_path, 'r') as file:
+    def write(self, dataframe: DataFrame):
+        with open(self.file_path, 'r') as file:
             singed_post = json.loads(file.read())
 
         signed_url = singed_post.get('url')

--- a/src/tests/lib/config/fixtures.py
+++ b/src/tests/lib/config/fixtures.py
@@ -212,6 +212,11 @@ def json_format_sample():
 
 
 @fixture
+def sql_format_sample():
+    return {'type': 'sql'}
+
+
+@fixture
 def unknown_format_sample():
     return {'type': 'unknown'}
 

--- a/src/tests/lib/config/fixtures.py
+++ b/src/tests/lib/config/fixtures.py
@@ -227,6 +227,15 @@ def file_writer_sample():
 
 
 @fixture
+def sql_writer_sample():
+    return {'type': 'sql',
+            'options': {
+                'method': 'cli',
+                'engine': 'mysql'
+            }}
+
+
+@fixture
 def s3_writer_sample():
     return {'type': 's3'}
 

--- a/src/tests/lib/config/test_formatters.py
+++ b/src/tests/lib/config/test_formatters.py
@@ -19,6 +19,12 @@ class TestFormattersConfiguration(object):
         assert rules is not None
         assert isinstance(rules, dict) is True
 
+    def test_sql(self, sql_format_sample):
+        rules = FormattersConfiguration.get_rules(sql_format_sample)
+
+        assert rules is not None
+        assert isinstance(rules, dict) is True
+
     def test_unknown(self, unknown_format_sample):
         with raises(ValueError):
             FormattersConfiguration.get_rules(unknown_format_sample)

--- a/src/tests/lib/config/test_serializers.py
+++ b/src/tests/lib/config/test_serializers.py
@@ -13,6 +13,12 @@ class TestSerializersConfiguration(object):
         assert rules is not None
         assert isinstance(rules, dict) is True
 
+    def test_sql(self, sql_writer_sample):
+        rules = SerializersConfiguration.get_rules(sql_writer_sample)
+
+        assert rules is not None
+        assert isinstance(rules, dict) is True
+
     def test_s3(self, s3_writer_sample):
         rules = SerializersConfiguration.get_rules(s3_writer_sample)
 

--- a/src/tests/lib/formatters/test_sql.py
+++ b/src/tests/lib/formatters/test_sql.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from pytest import raises
 
 from src.lib.formatters.sql import SQLFormatter
 from src.tests.lib.formatters.fixtures import *  # noqa: F403, F401
@@ -10,7 +11,7 @@ class TestSqlFormatter(object):
     def test_writting_dataframe_with_records(self,
                                              pandas_dataframe_with_data):
         buffer = StringIO()
-        csv_writer = SQLFormatter(specification={
+        sql_writer = SQLFormatter(specification={
             'options': {
                 'table_name': 'mytable',
                 'batch_size': 2,
@@ -21,7 +22,7 @@ class TestSqlFormatter(object):
                 }
             }
         })
-        csv_writer.format(dataframe=pandas_dataframe_with_data,
+        sql_writer.format(dataframe=pandas_dataframe_with_data,
                           path_or_buffer=buffer)
 
         assert isinstance(buffer.getvalue(), str) is True
@@ -134,3 +135,69 @@ class TestSqlFormatter(object):
 
         assert isinstance(buffer.getvalue(), str) is True
         assert len(buffer.getvalue()) == 0
+
+    def test_truncate(self, pandas_dataframe_with_data):
+        buffer = StringIO()
+        table_name = 'mytable'
+        sql_writer = SQLFormatter(specification={
+            'options': {
+                'mode': 'truncate',
+                'table_name': table_name,
+                'batch_size': 2,
+                'schema': {
+                    'Column': {
+                        'quoted': True
+                    }
+                }
+            }
+        })
+        sql_writer.format(dataframe=pandas_dataframe_with_data,
+                          path_or_buffer=buffer)
+
+        text = buffer.getvalue()
+        assert isinstance(text, str) is True
+        assert len(text) > 0
+        assert f'TRUNCATE {table_name}' in text
+
+    def test_replace(self, pandas_dataframe_with_data):
+        buffer = StringIO()
+        table_name = 'mytable'
+        sql_writer = SQLFormatter(specification={
+            'options': {
+                'mode': 'replace',
+                'table_name': table_name,
+                'batch_size': 2,
+                'schema': {
+                    'Column': {
+                        'quoted': True
+                    }
+                }
+            }
+        })
+        sql_writer.format(dataframe=pandas_dataframe_with_data,
+                          path_or_buffer=buffer)
+
+        text = buffer.getvalue()
+        assert isinstance(text, str) is True
+        assert len(text) > 0
+        assert f'DROP TABLE IF EXISTS {table_name};' in text
+
+    def test_invalid_mode(self, pandas_dataframe_with_data):
+        buffer = StringIO()
+        table_name = 'mytable'
+        sql_writer = SQLFormatter(specification={
+            'options': {
+                'mode': 'invalid',
+                'table_name': table_name,
+                'batch_size': 2,
+                'schema': {
+                    'Column': {
+                        'quoted': True
+                    }
+                }
+            }
+        })
+
+        with raises(ValueError):
+            sql_writer.format(dataframe=pandas_dataframe_with_data,
+                              path_or_buffer=buffer)

--- a/src/tests/lib/mysql/test_connection.py
+++ b/src/tests/lib/mysql/test_connection.py
@@ -1,0 +1,17 @@
+from src.lib.mysql.connection import MysqlConnection
+
+
+class TestMysqlConnection(object):
+
+    def test_execute(self, mocker):
+        mock_conn = mocker.patch('MySQLdb.connections.Connection')
+        mock_conn.cursor.return_value = lambda x: 0
+
+        with MysqlConnection(host='',
+                             username='',
+                             password='',
+                             port=3306,
+                             database='') as conn:
+            conn.execute_query('')
+
+        mock_conn.assert_called()

--- a/src/tests/lib/writers/databases/fixtures.py
+++ b/src/tests/lib/writers/databases/fixtures.py
@@ -1,0 +1,32 @@
+from pytest import fixture
+
+
+@fixture
+def mysql_specification():
+    return {
+        "type": "sql",
+        "options": {
+            "engine": "mysql",
+            "method": "cli",
+            "host": "",
+            "port": 3306,
+            "database": "",
+            "schema": "",
+            "username": "",
+            "password": ""
+        }
+    }
+
+
+@fixture
+def sql_formatter():
+    return {
+        'options': {
+            'table_name': 'mytable',
+            "mode": "truncate",
+            'batch_size': 2,
+            'schema': {
+                'Column': {'quoted': True}
+            }
+        }
+    }

--- a/src/tests/lib/writers/databases/test_mysql.py
+++ b/src/tests/lib/writers/databases/test_mysql.py
@@ -1,0 +1,49 @@
+from src.lib.formatters.sql import SQLFormatter
+from src.lib.writers.databases.mysql import MysqlDatabaseWriter
+from src.tests.lib.writers.fixtures import *  # noqa: F403, F401
+from src.tests.lib.writers.databases.fixtures import *  # noqa: F403, F401
+
+
+class TestMysqlDatabaseWriter(object):
+    def test_before_write(self, mocker, sql_formatter, mysql_specification):
+        expected = "123"
+        mock = mocker.patch('getpass._raw_input')
+        mock.return_value = expected
+
+        formatter = SQLFormatter(specification=sql_formatter)
+        writer = MysqlDatabaseWriter(formatter=formatter,
+                                     specification={'options': {}})
+        writer.before_write()
+
+        mock.assert_called()
+        assert writer.specification['options']['password'] == expected
+
+    def test_writting_csv_with_records(self,
+                                       mocker,
+                                       pandas_dataframe_with_data,
+                                       sql_formatter,
+                                       mysql_specification):
+        mock_conn = mocker.patch('MySQLdb.connections.Connection')
+        mock_conn.cursor.return_value = lambda x: 0
+
+        formatter = SQLFormatter(specification=sql_formatter)
+        writer = MysqlDatabaseWriter(formatter=formatter,
+                                     specification=mysql_specification)
+        writer.write(dataframe=pandas_dataframe_with_data)
+
+        mock_conn.assert_called()
+
+    def test_writting_dataframe_without_records(self,
+                                                mocker,
+                                                sql_formatter,
+                                                pandas_dataframe_without_data,
+                                                mysql_specification):
+        mock_conn = mocker.patch('MySQLdb.connections.Connection')
+        mock_conn.cursor.return_value = lambda x: 0
+
+        formatter = SQLFormatter(specification={})
+        writer = MysqlDatabaseWriter(formatter=formatter,
+                                     specification=mysql_specification)
+        writer.write(dataframe=pandas_dataframe_without_data)
+
+        mock_conn.assert_not_called()

--- a/src/tests/lib/writers/remotes/fixtures.py
+++ b/src/tests/lib/writers/remotes/fixtures.py
@@ -76,6 +76,11 @@ def specification_without_url():
 
 
 @fixture
+def gcs_without_url():
+    return {'type': 's3-url'}
+
+
+@fixture
 def signed_post_file():
     return '{"url": "s3.url.com", "fields": {}}'
 

--- a/src/tests/lib/writers/remotes/test_s3_presigned_url.py
+++ b/src/tests/lib/writers/remotes/test_s3_presigned_url.py
@@ -80,6 +80,7 @@ class TestS3PresignedUrlRemoteWriter(object):
                 formatter=formatter,
                 specification=specification_without_url
             )
+            writer.before_write()
             signed_url = writer.write(dataframe=pandas_dataframe_without_data)
 
             mock_post.assert_called()
@@ -109,7 +110,7 @@ class TestS3PresignedUrlRemoteWriter(object):
             )
 
             with raises(ValueError):
-                writer.write(dataframe=pandas_dataframe_without_data)
+                writer.before_write()
 
                 mock_post.assert_called()
                 mock_file.assert_called()


### PR DESCRIPTION
- feat(lib): add mysqlclient library to the project
- feat(mysql): add a class to manage mysql connection
- feat(mysql): add a mysql via client writer
- feat(inputs): add metaprogramming method to get needed inputs before execute
- refactor(before_write): update code to do inputs before write
- style(dataset): update dataset information to be not restricted to file systems
- feat(database_writers): create new flux to execute database writers
- fix(class): update init class and with statements
- feat(mysql_writer): finished implementation of mysql writer
- feat(tests): add unit-tests to all the code created and refactored for mysql writer